### PR TITLE
Int64 new

### DIFF
--- a/ast.ml
+++ b/ast.ml
@@ -89,6 +89,7 @@ module Meta = struct
 		| IfFeature
 		| Impl
 		| PythonImport
+		| ImplicitCast
 		| Include
 		| InitPackage
 		| Internal

--- a/codegen.ml
+++ b/codegen.ml
@@ -1604,10 +1604,11 @@ struct
 		| r :: ret ->
 			rm_duplicates (r :: acc) ret
 
-(* 	let s_options rated =
-		String.concat ",\n" (List.map (fun ((_,t),rate) ->
+	let s_options rated =
+		String.concat ",\n" (List.map (fun ((elist,t,_),rate) ->
+			"( " ^ (String.concat "," (List.map (fun(e,_) -> s_expr (s_type (print_context())) e) elist)) ^ " ) => " ^
 			"( " ^ (String.concat "," (List.map (fun (i,i2) -> string_of_int i ^ ":" ^ string_of_int i2) rate)) ^ " ) => " ^ (s_type (print_context()) t)
-		) rated) *)
+		) rated)
 
 	let count_optionals elist =
 		List.fold_left (fun acc (_,is_optional) -> if is_optional then acc + 1 else acc) 0 elist
@@ -1645,6 +1646,9 @@ struct
 					with | Not_found -> ())
 				| _ -> assert false
 			) compatible;
+
+			print_endline "=====";
+			print_endline (s_options (!rated));
 
 			let rec loop best rem = match best, rem with
 				| _, [] -> best

--- a/codegen.ml
+++ b/codegen.ml
@@ -690,7 +690,10 @@ module AbstractCast = struct
 			if (Meta.has Meta.MultiType a.a_meta) then
 				mk_cast eright tleft p
 			else match a.a_impl with
-				| Some c -> recurse cf (fun () -> make_static_call ctx c cf a tl [eright] tleft p)
+				| Some c -> recurse cf (fun () ->
+					let ret = make_static_call ctx c cf a tl [eright] tleft p in
+					{ ret with eexpr = TMeta( (Meta.ImplicitCast,[],ret.epos), ret) }
+				)
 				| None -> assert false
 		in
 		if type_iseq tleft eright.etype then
@@ -1513,6 +1516,13 @@ struct
 		List.iter2 (fun f a -> if not (type_iseq f a) then incr acc) tlfun tlarg;
 		!acc
 
+	(**
+		The rate function returns an ( int * int ) type.
+		The smaller the int, the best rated the caller argument is in comparison with the callee.
+
+		The first int refers to how many "conversions" would be necessary to convert from the callee to the caller type, and
+		the second refers to the type parameters.
+	**)
 	let rec rate_conv cacc tfun targ =
 		match simplify_t tfun, simplify_t targ with
 		| TInst({ cl_interface = true } as cf, tlf), TInst(ca, tla) ->
@@ -1635,7 +1645,14 @@ struct
 				| [], [] -> acc
 				| (_,true) :: elist, _ :: args -> mk_rate acc elist args
 				| (e,false) :: elist, (n,o,t) :: args ->
-					mk_rate (rate_conv 0 t e.etype :: acc) elist args
+					(* if the argument is an implicit cast, we need to start with a penalty *)
+					(* The penalty should be higher than any other implicit cast - other than Dynamic *)
+					(* since Dynamic has a penalty of max_int, we'll impose max_int - 1 to it *)
+					(match e.eexpr with
+						| TMeta( (Meta.ImplicitCast,_,_), _) ->
+							mk_rate ((max_int - 1, 0) :: acc) elist args
+						| _ ->
+							mk_rate (rate_conv 0 t e.etype :: acc) elist args)
 				| _ -> assert false
 			in
 
@@ -1646,9 +1663,6 @@ struct
 					with | Not_found -> ())
 				| _ -> assert false
 			) compatible;
-
-			print_endline "=====";
-			print_endline (s_options (!rated));
 
 			let rec loop best rem = match best, rem with
 				| _, [] -> best

--- a/common.ml
+++ b/common.ml
@@ -409,6 +409,7 @@ module MetaInfo = struct
 		| IfFeature -> ":ifFeature",("Causes a field to be kept by DCE if the given feature is part of the compilation",[HasParam "Feature name";UsedOn TClassField])
 		| Impl -> ":impl",("Used internally to mark abstract implementation fields",[UsedOn TAbstractField; Internal])
 		| PythonImport -> ":pythonImport",("Generates python import statement for extern classes",[Platforms [Python]; UsedOn TClass])
+		| ImplicitCast -> ":implicitCast",("Generated automatically on the AST when an implicit abstract cast happens",[Internal; UsedOn TExpr])
 		| Include -> ":include",("",[Platform Cpp])
 		| InitPackage -> ":initPackage",("?",[])
 		| Meta.Internal -> ":internal",("Generates the annotated field/class with 'internal' access",[Platforms [Java;Cs]; UsedOnEither[TClass;TEnum;TClassField]])

--- a/genjava.ml
+++ b/genjava.ml
@@ -84,7 +84,7 @@ let is_java_basic_type t =
 		| TInst( { cl_path = (["haxe"], "Int32") }, [] )
 		| TInst( { cl_path = (["haxe"], "Int64") }, [] )
 		| TAbstract( { a_path = ([], "Single") }, [] )
-		| TAbstract( { a_path = (["java"], ("Int8" | "Int16" | "Char16")) }, [] )
+		| TAbstract( { a_path = (["java"], ("Int8" | "Int16" | "Char16" | "Int64")) }, [] )
 		| TAbstract( { a_path =	([], "Int") }, [] )
 		| TAbstract( { a_path =	([], "Float") }, [] )
 		| TAbstract( { a_path =	([], "Bool") }, [] ) ->
@@ -234,6 +234,8 @@ struct
 							mk_is true obj i16_md
 						| TAbstractDecl{ a_path = (["java"], "Char16") } ->
 							mk_is true obj c16_md
+						| TAbstractDecl{ a_path = (["java"], "Int64") } ->
+							mk_is true obj i64_md
 						| TClassDecl{ cl_path = (["haxe"], "Int64") } ->
 							mk_is true obj i64_md
 						| TAbstractDecl{ a_path = ([], "Dynamic") }
@@ -861,6 +863,7 @@ let configure gen =
 			| TAbstract ({ a_path = ["java"],"Int16" },[])
 			| TType ({ t_path = ["java"],"Char16" },[])
 			| TAbstract ({ a_path = ["java"],"Char16" },[])
+			| TAbstract ({ a_path = ["java"],"Int64" },[])
 			| TType ({ t_path = [],"Single" },[])
 			| TAbstract ({ a_path = [],"Single" },[]) ->
 					Some t

--- a/std/java/StdTypes.hx
+++ b/std/java/StdTypes.hx
@@ -24,7 +24,7 @@ package java;
 @:notNull @:runtimeValue @:coreType abstract Int8 from Int {}
 @:notNull @:runtimeValue @:coreType abstract Int16 from Int {}
 @:notNull @:runtimeValue @:coreType abstract Char16 from Int {}
-@:notNull @:runtimeValue @:coreType abstract Int64 from Int from Float from haxe.Int64
+@:notNull @:runtimeValue @:coreType abstract Int64 from Int from Float
 {
 	@:op(A+B) public static function addI(lhs:Int64, rhs:Int):Int64;
 	@:op(A+B) public static function add(lhs:Int64, rhs:Int64):Int64;
@@ -56,4 +56,9 @@ package java;
 
 	@:op(~A) public static function bneg(t:Int64):Int64;
 	@:op(-A) public static function neg(t:Int64):Int64;
+
+	@:op(++A) public static function preIncrement(t:Int64):Int64;
+	@:op(A++) public static function postIncrement(t:Int64):Int64;
+	@:op(--A) public static function preDecrement(t:Int64):Int64;
+	@:op(A--) public static function postDecrement(t:Int64):Int64;
 }

--- a/std/java/_std/haxe/Int64.hx
+++ b/std/java/_std/haxe/Int64.hx
@@ -21,122 +21,189 @@
  */
 package haxe;
 using haxe.Int64;
-import java.StdTypes.Int64 in NativeInt64;
+
+private typedef __Int64 = java.StdTypes.Int64;
 
 @:coreApi
-@:nativeGen class Int64
+abstract Int64(__Int64) from __Int64 to __Int64
 {
-	@:extern private static inline function asNative(i:Int64):NativeInt64 return untyped i;
-	@:extern private static inline function ofNative(i:NativeInt64):Int64 return untyped i;
-	@:extern private static inline function mkNative(i:Int):NativeInt64 return cast i;
 
-	public static inline function make( high : Int, low : Int ) : Int64
-	{
-		return ((cast(high, NativeInt64) << 32 ) | (low & untyped __java__('0xffffffffL'))).ofNative();
-	}
+	public static inline function make( high : Int32, low : Int32 ) : Int64
+		return new Int64( (cast(high, __Int64) << 32) | (low & untyped __java__('0xffffffffL')) );
 
-	public static inline function getLow( x : Int64 ) : Int
-	{
-		return cast (x.asNative() & (untyped __java__("0xFFFFFFFFL")), Int);
-	}
+	private inline function new(x : __Int64)
+		this = x;
 
-	public static inline function getHigh( x : Int64 ) : Int {
-		return cast(cast(x,NativeInt64) >>> 32, Int);
-	}
+	private var val( get, set ) : __Int64;
+	inline function get_val() : __Int64 return this;
+	inline function set_val( x : __Int64 ) : __Int64 return this = x;
 
-	public static inline function ofInt( x : Int ) : Int64 {
+	public inline function copy():Int64
+		return new Int64( this );
+
+	@:from public static inline function ofInt( x : Int ) : Int64
 		return cast x;
+
+	public static inline function toInt( x : Int64 ) : Int {
+		if( x.val < 0x80000000 || x.val > 0x7FFFFFFF )
+			throw "Overflow";
+		return cast x.val;
 	}
 
-	public static inline function toInt( x : Int64 ) : Int
-	{
-		return cast x;
-	}
+	public static inline function getHigh( x : Int64 ) : Int32
+		return cast( x.val >> 32 );
 
-	public static inline function add( a : Int64, b : Int64 ) : Int64
-	{
-		return (a.asNative() + b.asNative()).ofNative();
-	}
+	public static inline function getLow( x : Int64 ) : Int32
+		return cast( x.val );
 
-	public static inline function sub( a : Int64, b : Int64 ) : Int64
-	{
-		return (a.asNative() - b.asNative()).ofNative();
-	}
+	public static inline function isNeg( x : Int64 ) : Bool
+		return x.val < 0;
 
-	public static inline function mul( a : Int64, b : Int64 ) : Int64 {
-		return (a.asNative() * b.asNative()).ofNative();
-	}
-
-	static function divMod( modulus : Int64, divisor : Int64 ) : { quotient : Int64, modulus : Int64 }
-	{
-		var q:Int64 = (modulus.asNative() / divisor.asNative()).ofNative();
-		var m:Int64 = (modulus.asNative() % divisor.asNative()).ofNative();
-		return { quotient : q, modulus : m };
-	}
-
-	public static inline function div( a : Int64, b : Int64 ) : Int64 {
-		return (a.asNative() / b.asNative()).ofNative();
-	}
-
-	public static inline function mod( a : Int64, b : Int64 ) : Int64 {
-		return (a.asNative() % b.asNative()).ofNative();
-	}
-
-	public static inline function shl( a : Int64, b : Int ) : Int64 {
-		return (a.asNative() << b).ofNative();
-	}
-
-	public static inline function shr( a : Int64, b : Int ) : Int64 {
-		return (a.asNative() >> b).ofNative();
-	}
-
-	public static inline function ushr( a : Int64, b : Int ) : Int64 {
-		return ( a.asNative() >>> b).ofNative();
-	}
-
-	public static inline function and( a : Int64, b : Int64 ) : Int64
-	{
-		return (a.asNative() & b.asNative()).ofNative();
-	}
-
-	public static inline function or( a : Int64, b : Int64 ) : Int64
-	{
-		return (a.asNative() | b.asNative()).ofNative();
-	}
-
-	public static inline function xor( a : Int64, b : Int64 ) : Int64
-	{
-		return (a.asNative() ^ b.asNative()).ofNative();
-	}
-
-	public static inline function neg( a : Int64 ) : Int64
-	{
-		return (-(a.asNative())).ofNative();
-	}
-
-	public static inline function isNeg( a : Int64 ) : Bool
-	{
-		return (a.asNative() < 0.mkNative());
-	}
-
-	public static inline function isZero( a : Int64 ) : Bool
-	{
-		return (a.asNative() == 0.mkNative());
-	}
+	public static inline function isZero( x : Int64 ) : Bool
+		return x.val == 0;
 
 	public static inline function compare( a : Int64, b : Int64 ) : Int
 	{
-		return (a.asNative() < b.asNative()) ? -1 : (a.asNative() > b.asNative()) ? 1 : 0;
+		if( a.val < b.val ) return -1;
+		if( a.val > b.val ) return 1;
+		return 0;
 	}
 
-	public static function ucompare( a : Int64, b : Int64 ) : Int
-	{
-		if (a.asNative() < 0.mkNative())
-			return (b.asNative() < 0.mkNative()) ? compare( (~(a.asNative())).ofNative(), (~(b.asNative())).ofNative()) : 1;
-		return (b.asNative() < 0.mkNative()) ? -1 : compare(a, b);
+	public static inline function ucompare( a : Int64, b : Int64 ) : Int {
+		if( a.val < 0 )
+			return ( b.val < 0 ) ? compare( a, b ) : 1;
+		return ( b.val < 0 ) ? -1 : compare( a, b );
 	}
 
-	public static inline function toStr( a : Int64 ) : String {
-		return a + "";
-	}
+	public static inline function toStr( x : Int64 ) : String
+		return x.val + "";
+
+	public static inline function divMod( dividend : Int64, divisor : Int64 ) : { quotient : Int64, modulus : Int64 }
+		return {quotient:0,modulus:0};//{ quotient: dividend / divisor, modulus: dividend % divisor };
+
+	private inline function toString() : String
+		return this + "";
+
+	@:op(-A) public static function neg( x : Int64 ) : Int64
+		return -x.val;
+
+	@:op(++A) private inline function preIncrement() : Int64
+		return ++this;
+
+	@:op(A++) private inline function postIncrement() : Int64
+		return this++;
+
+	@:op(--A) private inline function preDecrement() : Int64
+		return --this;
+
+	@:op(A--) private inline function postDecrement() : Int64
+		return this--;
+	
+	@:op(A + B) public static inline function add( a : Int64, b : Int64 ) : Int64
+		return a.val + b.val;
+
+	@:op(A + B) @:commutative private static inline function addInt( a : Int64, b : Int ) : Int64
+		return a.val + b;
+
+	@:op(A - B) public static inline function sub( a : Int64, b : Int64 ) : Int64
+		return a.val - b.val;
+
+	@:op(A - B) private static inline function subInt( a : Int64, b : Int ) : Int64
+		return a.val - b;
+
+	@:op(A - B) private static inline function intSub( a : Int, b : Int64 ) : Int64
+		return a - b.val;
+
+	@:op(A * B) public static inline function mul( a : Int64, b : Int64 ) : Int64
+		return a.val * b.val;
+
+	@:op(A * B) @:commutative private static inline function mulInt( a : Int64, b : Int ) : Int64
+		return a.val * b;
+
+	@:op(A / B) public static inline function div( a : Int64, b : Int64 ) : Int64
+		return a.val / b.val;
+
+	@:op(A / B) private static inline function divInt( a : Int64, b : Int ) : Int64
+		return a.val / b;
+
+	@:op(A / B) private static inline function intDiv( a : Int, b : Int64 ) : Int64
+		return a / b.val;
+
+	@:op(A % B) public static inline function mod( a : Int64, b : Int64 ) : Int64
+		return a.val % b.val;
+
+	@:op(A % B) private static inline function modInt( a : Int64, b : Int ) : Int64
+		return a.val % b;
+
+	@:op(A % B) private static inline function intMod( a : Int, b : Int64 ) : Int64
+		return a % b.val;
+
+	@:op(A == B) public static inline function eq( a : Int64, b : Int64 ) : Bool
+		return a.val == b.val;
+
+	@:op(A == B) @:commutative private static inline function eqInt( a : Int64, b : Int ) : Bool
+		return a.val == b;
+
+	@:op(A != B) public static inline function neq( a : Int64, b : Int64 ) : Bool
+		return a.val != b.val;
+
+	@:op(A != B) @:commutative private static inline function neqInt( a : Int64, b : Int ) : Bool
+		return a.val != b;
+
+	@:op(A < B) private static inline function lt( a : Int64, b : Int64 ) : Bool
+		return a.val < b.val;
+
+	@:op(A < B) private static inline function ltInt( a : Int64, b : Int ) : Bool
+		return a.val < b;
+
+	@:op(A < B) private static inline function intLt( a : Int, b : Int64 ) : Bool
+		return a < b.val;
+
+	@:op(A <= B) private static inline function lte( a : Int64, b : Int64 ) : Bool
+		return a.val <= b.val;
+
+	@:op(A <= B) private static inline function lteInt( a : Int64, b : Int ) : Bool
+		return a.val <= b;
+
+	@:op(A <= B) private static inline function intLte( a : Int, b : Int64 ) : Bool
+		return a <= b.val;
+
+	@:op(A > B) private static inline function gt( a : Int64, b : Int64 ) : Bool
+		return a.val > b.val;
+
+	@:op(A > B) private static inline function gtInt( a : Int64, b : Int ) : Bool
+		return a.val > b;
+
+	@:op(A > B) private static inline function intGt( a : Int, b : Int64 ) : Bool
+		return a > b.val;
+
+	@:op(A >= B) private static inline function gte( a : Int64, b : Int64 ) : Bool
+		return a.val >= b.val;
+
+	@:op(A >= B) private static inline function gteInt( a : Int64, b : Int ) : Bool
+		return a.val >= b;
+
+	@:op(A >= B) private static inline function intGte( a : Int, b : Int64 ) : Bool
+		return a >= b.val;
+
+	@:op(~A) private static inline function complement( x : Int64 ) : Int64
+		return ~x.val;
+
+	@:op(A & B) public static inline function and( a : Int64, b : Int64 ) : Int64
+		return a.val & b.val;
+
+	@:op(A | B) public static inline function or( a : Int64, b : Int64 ) : Int64
+		return a.val | b.val;
+
+	@:op(A ^ B) public static inline function xor( a : Int64, b : Int64 ) : Int64
+		return a.val ^ b.val;
+
+	@:op(A << B) public static inline function shl( a : Int64, b : Int ) : Int64
+		return a.val << b;
+
+	@:op(A >> B) public static inline function shr( a : Int64, b : Int ) : Int64
+		return a.val >> b;
+
+	@:op(A >>> B) public static inline function ushr( a : Int64, b : Int ) : Int64
+		return a.val >>> b;
 }

--- a/tests/unit/src/unit/TestInt64.hx
+++ b/tests/unit/src/unit/TestInt64.hx
@@ -1,4 +1,333 @@
 package unit;
+
+using haxe.Int64;
+
+class TestInt64 extends Test {
+
+	public function testMake() {
+		var a : Int64, i : Int;
+
+		// Test creation and fields
+		a = Int64.make(10,0xFFFFFFFF);
+		eq( a.getHigh(), 10 );
+		eq( a.getLow(), 0xFFFFFFFF );
+
+		// Int casts
+		a = 1;
+		eq( a.toInt(), 1 );
+
+		a = -1;
+		eq( a.getHigh(), 0xFFFFFFFF );
+		eq( a.getLow(), 0xFFFFFFFF );
+		eq( a.toInt(), -1 );
+
+		a = Int64.make(0,0x80000000);
+		eq( a.getHigh(), 0 );
+		eq( a.getLow(), 0x80000000 );
+		exc( tryOverflow.bind(a) );	// Throws Overflow
+
+		a = Int64.make(0xFFFFFFFF,0x80000000);
+		eq( a.getHigh(), 0xFFFFFFFF );
+		eq( a.getLow(), 0x80000000 );
+		eq( a.toInt(), -2147483648 );
+
+		a = Int64.make(0xFFFFFFFF,0x7FFFFFFF);
+		eq( a.getHigh(), 0xFFFFFFFF );
+		eq( a.getLow(), 0x7FFFFFFF );
+		exc( tryOverflow.bind(a) );	// Throws Overflow
+	}
+
+	function tryOverflow( a : Int64 )
+	{
+		a.toInt();
+	}
+
+	public function testCopy() {
+		var a : Int64, b : Int64;
+		a = 1;
+		b = a.copy();
+		++b;
+		f( a == b );
+	}
+
+	public function testToString() {
+		var a : Int64;
+
+		// Issue #903
+		a = 0;
+		eq( Std.string( a ), "0" );
+
+		a = 156;
+		eq( '$a', "156" );
+
+		a = -1;
+		eq( '$a', "-1" );
+
+		a = Int64.make(0xFFFFFFFE,0);
+		eq( a.toStr(), "-8589934592" );
+
+		a = Int64.make(1,1);
+		eq( a.toStr(), "4294967297" );
+	}
+
+	public function testComparison() {
+		var a : Int64, b : Int64;
+		a = 1; b = 1;
+		t( a == b ); f( a != b );
+		t( a <= b ); f( a < b );
+		t( a >= b ); f( a > b );
+		eq( a.compare(b), 0 );
+		eq( a.ucompare(b), 0 );
+
+		a = -10;
+		b = -15;
+		f( a == b ); t( a != b );
+		f( a <= b ); f( a < b );
+		t( a >= b ); t( a > b );
+		t( a.compare(b) > 0 );
+		t( a.ucompare(b) > 0 );
+
+		a = Int64.make(0,0);
+		b = Int64.make(1,0);
+		f( a == b ); t( a != b );
+		t( a <= b ); t( a < b );
+		f( a >= b ); f( a > b );
+		t( a.compare(b) < 0 );
+		t( a.ucompare(b) < 0 );
+
+		a = Int64.make(0x0FFFFFFF,0xFFFFFFFF);
+		b = Int64.make(0x80000000,0x80000000);
+		f( a == b ); t( a != b );
+		f( a <= b ); f( a < b );
+		t( a >= b ); t( a > b );
+		t( a.compare(b) > 0 );
+		t( a.ucompare(b) < 0 );
+
+		// Issue #2317
+		a = Int64.make(0xA, 0x828D97A8);
+		b = 0;
+		t( a.compare(b) > 0 );
+		t( a.ucompare(b) > 0 );
+
+		// Issue #2090
+		a = 0;
+		b = Int64.make(320, -2138504556);
+		t( a.compare(b) < 0 );
+		t( a.ucompare(b) < 0 );
+
+
+	}
+
+	public function testIncrement() {
+		var a = Int64.make(0,0xFFFFFFFF);
+		var b = a.copy();
+		var c = Int64.make(1,0);
+		int64eq( a++, b );
+		int64eq( a--, c );
+		int64eq( ++a, c );
+		int64eq( --a, b );
+	}
+
+	public function testAddition() {
+		var a : Int64, b : Int64;
+
+		a = Int64.make(0,0x9E370301);
+		b = Int64.make(0,0xB0590000);
+		int64eq( a+b, Int64.make(0x1,0x4E900301) );
+
+		// negation
+		b = -a;
+		int64eq( a+b, 0 );
+
+		// Int64+Int
+		int64eq( a+12345678, Int64.make(0,0x9EF3644F) );
+
+		// Int+Int64
+		int64eq( 0xF0002222+a, Int64.make(0,0x8E372523) );
+	}
+
+	public function testSubtraction() {
+		var a : Int64, b : Int64;
+
+		a = Int64.make(1,0);
+		b = Int64.make(0,1);
+		int64eq( a-b, Int64.make(0,0xFFFFFFFF) );
+
+		b = a;
+		int64eq( a-b, 0 );
+
+		b = Int64.make(0xFFFFFFFE,1);
+		int64eq( a-b, Int64.make(2,0xFFFFFFFF) );
+
+		// Int64-Int
+		int64eq( a-12345678, Int64.make(0,0xFF439EB2) );
+
+		// Int-Int64
+		int64eq( 12345678-a, Int64.make(0xFFFFFFFF,0x00BC614E) );
+	}
+
+	public function testMultiplication() {
+		var a : Int64, b : Int64;
+
+		a = Int64.make(0, 0x239B0E13);
+		b = Int64.make(0, 0x39193D1B);
+		int64eq( a*b, Int64.make(0x07F108C6,0x4E900301) );
+
+		a = Int64.make(0, 0xD3F9C9F4);
+		b = Int64.make(0, 0xC865C765);
+		int64eq( a*b, Int64.make(0xA5EF6C6E,0x1ACD5944) );
+
+		var a = Int64.make(0xFFF21CDA, 0x972E8BA3);
+		var b = Int64.make(0x0098C29B, 0x81000001);
+		int64eq( a*b, Int64.make(0xDDE8A2E8, 0xBA2E8BA3) );
+
+		var a = Int64.make(0x81230000, 0x81230000);
+		var b = Int64.make(0x90909090, 0x90909090);
+		int64eq( a*b, Int64.make(0xF04C9C9C,0x53B00000) );
+
+		var a = Int64.make(0x00001000, 0x0020020E);
+		var b = Int64.make(0xBEDBEDED, 0xDEBDEBDE);
+		int64eq( a*b, Int64.make(0xC45C967D,0x25FAA224) );
+
+		// Issue #1532
+		a = Int64.make(0xFFF21CDA, 0x972E8BA3);
+    	b = Int64.make(0x0098C29B, 0x81000001);
+    	int64eq( a*b, Int64.make(0xDDE8A2E8, 0xBA2E8BA3) );
+
+		// Int64*Int
+		a = Int64.make(0x01000000, 0x11131111);
+		int64eq( a*7, Int64.make(0x07000000,0x77857777) );
+
+		// Int*Int64
+		a = Int64.make(0x91111111, 0x11111111);
+		int64eq( 2*a, Int64.make(0x22222222,0x22222222) );
+	}
+
+	public function testDivision() {
+		var a : Int64, b : Int64;
+
+		a = Int64.make(0x00002342, 0xDDEF3421);
+		b = Int64.make(0x00000001, 0x00002000);
+		int64eq( a/b, 9026 );
+		int64eq( a%b, Int64.make(0,0xD986F421) );
+		var result = a.divMod(b);
+		int64eq( a/b, result.quotient );
+		int64eq( a%b, result.modulus );
+
+		a = Int64.make(0xF0120AAA, 0xAAAAAAA0);
+		b = Int64.make(0x00020001, 0x0FF02000);
+		int64eq( a/b, -2038 );
+		int64eq( a%b, Int64.make(0xFFFE131F,0x8C496AA0) );
+		result = a.divMod(b);
+		int64eq( a/b, result.quotient );
+		int64eq( a%b, result.modulus );
+
+		a = Int64.make(0, 2);
+		b = Int64.make(0xFFFFFFFF, 0xFAFAFAFA);
+		int64eq( a/b, 0 );
+		int64eq( a%b, 2 );
+		result = a.divMod(b);
+		int64eq( a/b, result.quotient );
+		int64eq( a%b, result.modulus );
+
+		a = Int64.make(0x7ABADDAD, 0xDEADBEEF);
+		b = Int64.make(0xFFFFFFF1, 0x1FFFFFFF);
+		int64eq( a/b, Int64.make(0xFFFFFFFF,0xF7BFCEAE) );
+		int64eq( a%b, Int64.make(0x0000000A,0x166D8D9D) );
+		result = a.divMod(b);
+		int64eq( a/b, result.quotient );
+		int64eq( a%b, result.modulus );
+
+		a = Int64.make(0x81234567, 0xFDECBA98);
+		b = Int64.make(0xFFFFFEFF, 0xEEEEEEEE);
+		int64eq( a/b, 0x007ED446 );
+		int64eq( a%b, Int64.make(0xFFFFFFF5,0x31964D84) );
+		result = a.divMod(b);
+		int64eq( a/b, result.quotient );
+		int64eq( a%b, result.modulus );
+
+		// Int64/Int
+		int64eq( a/2, Int64.make(0xC091A2B3,0xFEF65D4C) );
+		int64eq( a%100, -68 );
+
+		// Int/Int64
+		int64eq( 10001/a, 0 );
+		int64eq( 515151%a, 515151 );
+	}
+
+	public function testBinaryOps() {
+		var a : Int64, b : Int64;
+
+		a = haxe.Int64.make(0x0FFFFFFF, 0x00000001);
+		b = haxe.Int64.make(0, 0x8FFFFFFF);
+		int64eq( a&b, 1 );
+		int64eq( a|b, Int64.make(0x0FFFFFFF, 0x8FFFFFFF) );
+		int64eq( a^b, Int64.make(0x0FFFFFFF, 0x8FFFFFFE) );
+		int64eq( ~a, Int64.make(0xF0000000, 0xFFFFFFFE) );
+	}
+
+	public function testShifts() {
+		var a : Int64;
+
+		a = 1 << 20;
+		int64eq( a, 0x100000 );
+
+		a <<= 20;
+		int64eq( a, Int64.make(0x100,0x00000000) );
+
+		a = -1;
+		a >>= 4;
+		int64eq( a, -1 );
+		a >>>= 4;
+		int64eq( a, Int64.make(0x0FFFFFFF,0xFFFFFFFF) );
+
+		// Ensure proper overflow behavior for shift operand
+		a = Int64.make(1,1);
+		int64eq( a << 0, a );
+		int64eq( a >> 0, a );
+		int64eq( a >>> 0, a );
+		int64eq( a << 64, a );
+		int64eq( a >> 64, a );
+		int64eq( a >>> 64, a );
+	}
+
+	/** Tests that we have all of the classic Int64 interface. */
+	public function testBackwardsCompat() {
+		var a : Int64 = 32.ofInt();
+		var b : Int64 = (-4).ofInt();
+
+		t( a.eq(b) );
+		t( a.neq(b) );
+		int64eq( a.add(b), 28 );
+		int64eq( a.sub(b), 36 );
+		int64eq( a.div(b), -8 );
+		int64eq( a.mod(b), 0 );
+		int64eq( b.shl(1), -8 );
+		int64eq( b.shr(1), -2 );
+		int64eq( b.ushr(1), Int64.make(0x7FFFFFFF,0xFFFFFFFE) );
+		int64eq( a.and(b), 32 );
+		int64eq( a.or(b), -4 );
+		int64eq( a.xor(b), -36 );
+		int64eq( a.neg(), -32 );
+		f( a.isNeg() );  t( b.isNeg() );
+		f( a.isZero() ); f( b.isZero() );
+		t( a.compare(b) > 0 );
+		t( a.ucompare(b) < 0 );
+		int64eq( a.toInt(), 32 );
+		int64eq( b.toInt(), -4 );
+	}
+
+	function int64eq( v : Int64, v2 : Int64, ?pos ) {
+		Test.count++;
+		if( v != v2 ) {
+			Test.report(Std.string(v)+" should be "+Std.string(v2),pos);
+			Test.success = false;
+		}
+	}
+}
+
+/*
+package unit;
 using haxe.Int64;
 import haxe.Int64.*;
 
@@ -113,3 +442,4 @@ class TestInt64 extends Test {
 		eq(Std.string(make(-2147483648, 1)), Std.string(neg(make(2147483647, -1)))); // -9223372036854775807 == neg(9223372036854775807)
 	}
 }
+*/

--- a/tests/unit/src/unit/TestInt64.hx
+++ b/tests/unit/src/unit/TestInt64.hx
@@ -37,6 +37,26 @@ class TestInt64 extends Test {
 		exc( tryOverflow.bind(a) );	// Throws Overflow
 	}
 
+	// Some tests of how it generates Int64 when used as Null<Int64> or as type parameters
+	function testGen()
+	{
+		var arr:Array<Int64> = [];
+		arr.push(1);
+		arr.push(Int64.make(0xFFFFFFFF,0x80000000));
+		eq(arr[0].getHigh(), 0);
+		eq(arr[0].getLow(), 1);
+		eq(arr[1].getHigh(), 0xFFFFFFFF);
+		eq(arr[1].getLow(), 0x80000000);
+
+		var n:Null<Int64> = null;
+		eq(n, null);
+		var dyn:Dynamic = n;
+		eq(dyn, null);
+		n = Int64.make(0xf0f0f0f0, 0xefefefef);
+		eq(n.getHigh(), 0xf0f0f0f0);
+		eq(n.getLow(), 0xefefefef);
+	}
+
 	function tryOverflow( a : Int64 )
 	{
 		a.toInt();

--- a/tests/unit/src/unit/TestJava.hx
+++ b/tests/unit/src/unit/TestJava.hx
@@ -119,7 +119,7 @@ class TestJava extends Test
 		var c = new TestMyClass();
 		c.normalOverload(true);
 		t(c.boolCalled);
-		c.normalOverload(10);
+		c.normalOverload(6161);
 		t(c.intCalled);
 		c.normalOverload(haxe.Int64.ofInt(0));
 		t(c.int64Called);


### PR DESCRIPTION
Disclaimer: I've fixed some other Int64 generation problems that Java had; I couldn't test on C# as it seems it hasn't been implemented yet; There were a lot of Int64 failures on Java, but I guess it's because you couldn't test them before I fixed those issues.
Also, I didn't test if my added @:implicitCast broke any target. We'll need to check that through Travis. But let me know if anything looks weird, which will probably be related to that TMeta added
